### PR TITLE
Add authentication APIs

### DIFF
--- a/backend/skillswipe_backend/authentication/serializers.py
+++ b/backend/skillswipe_backend/authentication/serializers.py
@@ -1,0 +1,29 @@
+from rest_framework import serializers
+from djoser.serializers import UserCreateSerializer, UserSerializer
+from django.contrib.auth import get_user_model
+
+User = get_user_model()
+
+
+class CustomUserCreateSerializer(UserCreateSerializer):
+    """Custom user registration serializer"""
+    
+    role = serializers.ChoiceField(choices=User.ROLE_CHOICES, required=True)
+    
+    class Meta(UserCreateSerializer.Meta):
+        model = User
+        fields = ('id', 'username', 'email', 'password', 'role')
+
+    def validate_email(self, value):
+        if User.objects.filter(email=value).exists():
+            raise serializers.ValidationError("A user with this email already exists.")
+        return value
+
+
+class CustomUserSerializer(UserSerializer):
+    """Custom user details serializer"""
+    
+    class Meta(UserSerializer.Meta):
+        model = User
+        fields = ('id', 'username', 'email', 'role', 'status', 'date_joined')
+        read_only_fields = ('id', 'role', 'status', 'date_joined')

--- a/backend/skillswipe_backend/authentication/urls.py
+++ b/backend/skillswipe_backend/authentication/urls.py
@@ -1,0 +1,14 @@
+from django.urls import path, include
+from . import views
+
+urlpatterns = [
+    # Djoser authentication URLs
+    path('auth/', include('djoser.urls')),
+    path('auth/', include('djoser.urls.jwt')),
+    
+    # Custom authentication endpoints
+    path('auth/login/', views.login_view, name='custom-login'),
+    path('auth/profile-status/', views.profile_status, name='profile-status'),
+    path('auth/ping/', views.update_activity, name='update-activity'),
+    path('auth/logout/', views.logout_view, name='custom-logout'),
+]

--- a/backend/skillswipe_backend/authentication/views.py
+++ b/backend/skillswipe_backend/authentication/views.py
@@ -1,3 +1,156 @@
-from django.shortcuts import render
+from rest_framework import status
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework.response import Response
+from rest_framework_simplejwt.tokens import RefreshToken
+from django.contrib.auth import get_user_model
+from django.utils import timezone
 
-# Create your views here.
+User = get_user_model()
+
+@api_view(['POST'])
+@permission_classes([AllowAny])
+def login_view(request):
+    """Custom login view that accepts email"""
+    email = request.data.get('email')
+    password = request.data.get('password')
+    
+    if not email or not password:
+        return Response({
+            'error': 'Email and password are required'
+        }, status=status.HTTP_400_BAD_REQUEST)
+    
+    try:
+        user = User.objects.get(email=email)
+        if user.check_password(password):
+            # Update last ping on login
+            user.update_last_ping()
+            
+            refresh = RefreshToken.for_user(user)
+            return Response({
+                'access': str(refresh.access_token),
+                'refresh': str(refresh),
+                'user': {
+                    'id': str(user.id),
+                    'username': user.username,
+                    'email': user.email,
+                    'role': user.role,
+                    'status': user.status
+                }
+            })
+        else:
+            return Response({
+                'error': 'Invalid credentials'
+            }, status=status.HTTP_401_UNAUTHORIZED)
+    except User.DoesNotExist:
+        return Response({
+            'error': 'Invalid credentials'
+        }, status=status.HTTP_401_UNAUTHORIZED)
+
+
+@api_view(['GET'])
+@permission_classes([IsAuthenticated])
+def profile_status(request):
+    """Check if user has completed profile creation"""
+    user = request.user
+    
+    # Check profile completion based on role
+    if user.role == 'developer':
+        has_profile = hasattr(user, 'developer_profile')
+        if has_profile:
+            profile = user.developer_profile
+            # Calculate completion percentage
+            required_fields = [
+                profile.name, profile.bio, profile.current_location,
+                profile.experience_years, profile.top_languages
+            ]
+            completed_fields = sum(1 for field in required_fields if field)
+            completion_percentage = int((completed_fields / len(required_fields)) * 100)
+            
+            next_step = None
+            if completion_percentage < 100:
+                if not profile.name:
+                    next_step = "add_name"
+                elif not profile.bio:
+                    next_step = "add_bio"
+                elif not profile.current_location:
+                    next_step = "add_location"
+                elif not profile.experience_years:
+                    next_step = "add_experience"
+                elif not profile.top_languages:
+                    next_step = "add_skills"
+        else:
+            completion_percentage = 0
+            next_step = "create_developer_profile"
+            
+    elif user.role == 'company':
+        # Check if user is associated with any company
+        has_profile = user.company_memberships.exists()
+        if has_profile:
+            company_membership = user.company_memberships.first()
+            company = company_membership.company
+            # Calculate completion for company
+            required_fields = [company.name, company.about, company.location]
+            completed_fields = sum(1 for field in required_fields if field)
+            completion_percentage = int((completed_fields / len(required_fields)) * 100)
+            
+            next_step = None
+            if completion_percentage < 100:
+                if not company.name:
+                    next_step = "add_company_name"
+                elif not company.about:
+                    next_step = "add_company_about"
+                elif not company.location:
+                    next_step = "add_company_location"
+        else:
+            completion_percentage = 0
+            next_step = "create_company_profile"
+    
+    return Response({
+        'has_profile': has_profile,
+        'profile_completion': completion_percentage,
+        'next_required_step': next_step,
+        'user_role': user.role,
+        'profile_mandatory': True  # Always mandatory 
+    })
+
+
+@api_view(['POST'])
+@permission_classes([IsAuthenticated])
+def update_activity(request):
+    """Update user's last activity (ping)"""
+    user = request.user
+    user.update_last_ping()
+    
+    return Response({
+        'message': 'Activity updated successfully',
+        'last_ping': user.last_ping,
+        'status': user.status
+    })
+
+
+# Update the logout_view function:
+
+@api_view(['POST'])
+@permission_classes([IsAuthenticated])
+def logout_view(request):
+    """Logout user (blacklist refresh token)"""
+    try:
+        refresh_token = request.data.get("refresh")
+        if not refresh_token:
+            return Response({
+                'error': 'Refresh token is required'
+            }, status=status.HTTP_400_BAD_REQUEST)
+            
+        from rest_framework_simplejwt.tokens import RefreshToken
+        token = RefreshToken(refresh_token)
+        token.blacklist()
+        
+        return Response({
+            'message': 'Logout successful'
+        }, status=status.HTTP_200_OK)
+    except Exception as e:
+        return Response({
+            'message': 'Invalid or expired refresh token',
+            'error': str(e)
+        }, status=status.HTTP_400_BAD_REQUEST)

--- a/backend/skillswipe_backend/skillswipe_backend/settings.py
+++ b/backend/skillswipe_backend/skillswipe_backend/settings.py
@@ -47,6 +47,7 @@ INSTALLED_APPS = [
     'rest_framework',
     'djoser',
     'rest_framework_simplejwt',
+    'rest_framework_simplejwt.token_blacklist',  # Add this line
     'corsheaders',
     
     # Local apps
@@ -148,7 +149,7 @@ REST_FRAMEWORK = {
     'PAGE_SIZE': 20
 }
 
-# Simple JWT Configuration
+# SIMPLE_JWT configuration
 SIMPLE_JWT = {
     'ACCESS_TOKEN_LIFETIME': timedelta(minutes=60),
     'REFRESH_TOKEN_LIFETIME': timedelta(days=7),
@@ -205,3 +206,17 @@ CORS_ALLOWED_HEADERS = [
 # Custom User Model
 AUTH_USER_MODEL = 'authentication.User'
 
+# Djoser Configuration 
+DJOSER = {
+    'LOGIN_FIELD': 'email',
+    'USER_ID_FIELD': 'email', 
+    'SEND_ACTIVATION_EMAIL': False,
+    'SERIALIZERS': {
+        'user_create': 'authentication.serializers.CustomUserCreateSerializer',
+        'user': 'authentication.serializers.CustomUserSerializer',
+        'token_create': 'djoser.serializers.TokenCreateSerializer',  
+    },
+    'PERMISSIONS': {
+        'user_create': ['rest_framework.permissions.AllowAny'],
+    },
+}

--- a/backend/skillswipe_backend/skillswipe_backend/urls.py
+++ b/backend/skillswipe_backend/skillswipe_backend/urls.py
@@ -19,6 +19,5 @@ from django.urls import path, include
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path('api/auth/', include('djoser.urls')),
-    path('api/auth/', include('djoser.urls.jwt')),
+    path('api/', include('authentication.urls')),
 ]


### PR DESCRIPTION
What this adds:
- User registration and login APIs
- Support for developer and company accounts
- JWT token authentication APIs
- Profile completion checking API
- User activity tracking API Files added/changed:
- authentication/serializers.py (user registration logic)
- authentication/views.py (login and user management APIs)
- authentication/urls.py (API routes)
- settings.py (authentication config) APIs created:
- Register: POST /api/auth/users/
- Login: POST /api/auth/login/
- Get profile: GET /api/auth/users/me/
- Check profile status: GET /api/auth/profile-status/
- Update activity: POST /api/auth/ping/
- Refresh token: POST /api/auth/jwt/refresh/
- Logout: POST /api/auth/logout/ All APIs tested and working with Postman